### PR TITLE
Update to latest version - 1.21.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	modImplementation  "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation  "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation ("com.terraformersmc:modmenu:16.0.0") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:17.0.0-beta.2") { exclude group: "net.fabricmc.fabric-api" }
 
 	testImplementation 'junit:junit:4.13.1';
 	compileOnly group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2";

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	modImplementation  "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation  "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation ("com.terraformersmc:modmenu:14.0.1") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:15.0.0-beta.3") { exclude group: "net.fabricmc.fabric-api" }
 
 	testImplementation 'junit:junit:4.13.1';
 	compileOnly group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2";

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	modImplementation  "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation  "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation ("com.terraformersmc:modmenu:15.0.1") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:16.0.0") { exclude group: "net.fabricmc.fabric-api" }
 
 	testImplementation 'junit:junit:4.13.1';
 	compileOnly group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2";

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.9-SNAPSHOT'
+	id 'fabric-loom' version '1.14-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -21,7 +21,7 @@ dependencies {
 	modImplementation  "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation  "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation ("com.terraformersmc:modmenu:13.0.0") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:14.0.1") { exclude group: "net.fabricmc.fabric-api" }
 
 	testImplementation 'junit:junit:4.13.1';
 	compileOnly group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2";

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	modImplementation  "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation  "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation ("com.terraformersmc:modmenu:15.0.0-beta.3") { exclude group: "net.fabricmc.fabric-api" }
+	modImplementation ("com.terraformersmc:modmenu:15.0.1") { exclude group: "net.fabricmc.fabric-api" }
 
 	testImplementation 'junit:junit:4.13.1';
 	compileOnly group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2";

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric Properties
-minecraft_version=1.21.10
-yarn_mappings=1.21.10+build.3
+minecraft_version=1.21.11
+yarn_mappings=1.21.11+build.4
 loader_version=0.18.4
 
 # Fabric API
-fabric_version=0.138.4+1.21.10
+fabric_version=0.141.1+1.21.11
 
 # Mod Properties
-mod_version=1.6.3-1.21.10
+mod_version=1.6.4-1.21.11
 maven_group=net.kyrptonaught
 archives_base_name=kyrptconfig

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric Properties
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.10
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.18.4
 
 # Fabric API
-fabric_version=0.114.2+1.21.4
+fabric_version=0.128.2+1.21.5
 
 # Mod Properties
-mod_version=1.6.1-1.21.4
+mod_version=1.6.1-1.21.5
 maven_group=net.kyrptonaught
 archives_base_name=kyrptconfig

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric Properties
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
+minecraft_version=1.21.9
+yarn_mappings=1.21.9+build.1
 loader_version=0.18.4
 
 # Fabric API
-fabric_version=0.136.1+1.21.8
+fabric_version=0.134.1+1.21.9
 
 # Mod Properties
-mod_version=1.6.2-1.21.8
+mod_version=1.6.3-1.21.9
 maven_group=net.kyrptonaught
 archives_base_name=kyrptconfig

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric Properties
-minecraft_version=1.21.6
-yarn_mappings=1.21.6+build.1
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
 loader_version=0.18.4
 
 # Fabric API
-fabric_version=0.128.2+1.21.6
+fabric_version=0.136.1+1.21.8
 
 # Mod Properties
-mod_version=1.6.2-1.21.6
+mod_version=1.6.2-1.21.8
 maven_group=net.kyrptonaught
 archives_base_name=kyrptconfig

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric Properties
-minecraft_version=1.21.5
-yarn_mappings=1.21.5+build.1
+minecraft_version=1.21.6
+yarn_mappings=1.21.6+build.1
 loader_version=0.18.4
 
 # Fabric API
-fabric_version=0.128.2+1.21.5
+fabric_version=0.128.2+1.21.6
 
 # Mod Properties
-mod_version=1.6.1-1.21.5
+mod_version=1.6.2-1.21.6
 maven_group=net.kyrptonaught
 archives_base_name=kyrptconfig

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,14 +2,14 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric Properties
-minecraft_version=1.21.9
-yarn_mappings=1.21.9+build.1
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.3
 loader_version=0.18.4
 
 # Fabric API
-fabric_version=0.134.1+1.21.9
+fabric_version=0.138.4+1.21.10
 
 # Mod Properties
-mod_version=1.6.3-1.21.9
+mod_version=1.6.3-1.21.10
 maven_group=net.kyrptonaught
 archives_base_name=kyrptconfig

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/ConfigManager.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/ConfigManager.java
@@ -1,6 +1,7 @@
 package net.kyrptonaught.kyrptconfig.config;
 
 import com.google.gson.GsonBuilder;
+import com.google.gson.Strictness;
 import net.fabricmc.loader.api.FabricLoader;
 import net.kyrptonaught.jankson.Jankson;
 import net.minecraft.util.Identifier;
@@ -36,8 +37,8 @@ public class ConfigManager {
         Gson = new GsonJsonLoader();
         ((GsonJsonLoader) Gson).provideGson(new GsonBuilder()
                 .setPrettyPrinting()
-                .setLenient()
-                .registerTypeAdapter(Identifier.class, new Identifier.Serializer())
+                .setStrictness(Strictness.LENIENT)
+                .registerTypeAdapter(Identifier.class, Identifier.CODEC)
                 .create());
     }
 

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/NonConflicting/NonConflictingKeyBindData.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/NonConflicting/NonConflictingKeyBindData.java
@@ -1,19 +1,21 @@
 package net.kyrptonaught.kyrptconfig.config.NonConflicting;
 
+import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 
 import java.util.function.Consumer;
 
 @Deprecated
 public class NonConflictingKeyBindData {
-    public String name, category;
+    public String name;
+    public KeyBinding.Category category;
     public InputUtil.Type inputType;
     public int keyCode;
     public Consumer<InputUtil.Key> keySetEvent;
     public String defaultKey;
 
     @Deprecated
-    public NonConflictingKeyBindData(String Name, String Category, InputUtil.Type type, int KeyCode, Consumer<InputUtil.Key> keySetEvent) {
+    public NonConflictingKeyBindData(String Name, KeyBinding.Category Category, InputUtil.Type type, int KeyCode, Consumer<InputUtil.Key> keySetEvent) {
         this.name = Name;
         this.category = Category;
         this.inputType = type;
@@ -22,7 +24,7 @@ public class NonConflictingKeyBindData {
     }
 
     @Deprecated
-    public NonConflictingKeyBindData(String Name, String Category, InputUtil.Key boundKey, String defaultKey, Consumer<InputUtil.Key> keySetEvent) {
+    public NonConflictingKeyBindData(String Name, KeyBinding.Category Category, InputUtil.Key boundKey, String defaultKey, Consumer<InputUtil.Key> keySetEvent) {
         this(Name, Category, boundKey.getCategory(), boundKey.getCode(), keySetEvent);
         this.defaultKey = defaultKey;
     }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/NonConflicting/NonConflictingKeyBinding.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/NonConflicting/NonConflictingKeyBinding.java
@@ -2,17 +2,18 @@ package net.kyrptonaught.kyrptconfig.config.NonConflicting;
 
 import net.kyrptonaught.kyrptconfig.keybinding.CustomKeyBinding;
 import net.kyrptonaught.kyrptconfig.keybinding.DisplayOnlyKeyBind;
+import net.minecraft.client.option.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 
 import java.util.function.Consumer;
 
 public class NonConflictingKeyBinding extends DisplayOnlyKeyBind {
 
-    public NonConflictingKeyBinding(String name, InputUtil.Type type, int code, String category) {
+    public NonConflictingKeyBinding(String name, InputUtil.Type type, int code, KeyBinding.Category category) {
         super(name, type, code, category);
     }
 
-    public NonConflictingKeyBinding(String translationKey, String category, CustomKeyBinding customKeyBinding, Consumer<InputUtil.Key> keySet) {
+    public NonConflictingKeyBinding(String translationKey, KeyBinding.Category category, CustomKeyBinding customKeyBinding, Consumer<InputUtil.Key> keySet) {
         super(translationKey, category, customKeyBinding, keySet);
     }
 }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigScreen.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigScreen.java
@@ -3,8 +3,11 @@ package net.kyrptonaught.kyrptconfig.config.screen;
 import com.mojang.blaze3d.opengl.GlStateManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gl.RenderPipelines;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.text.Text;
 import net.minecraft.util.Colors;
 import net.minecraft.util.Identifier;
@@ -132,27 +135,27 @@ public class ConfigScreen extends Screen {
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        if (sections.get(selectedSection).keyPressed(keyCode, scanCode, modifiers)) return true;
-        return super.keyPressed(keyCode, scanCode, modifiers);
+    public boolean keyPressed(KeyInput input) {
+        if (sections.get(selectedSection).keyPressed(input)) return true;
+        return super.keyPressed(input);
     }
 
     @Override
-    public boolean charTyped(char chr, int modifiers) {
-        return sections.get(selectedSection).charTyped(chr, modifiers);
+    public boolean charTyped(CharInput input) {
+        return sections.get(selectedSection).charTyped(input);
     }
 
     @Override
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
+    public boolean mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
 
-        if (scrollLeftBTN.mouseClicked(mouseX, mouseY, button) || scrollRightBTN.mouseClicked(mouseX, mouseY, button))
+        if (scrollLeftBTN.mouseClicked(click, doubled) || scrollRightBTN.mouseClicked(click, doubled))
             return true;
 
         for (ConfigSection section : sections)
-            if (section.sectionSelectionBTN.mouseClicked(mouseX, mouseY, button)) return true;
+            if (section.sectionSelectionBTN.mouseClicked(click, doubled)) return true;
 
-        return sections.get(selectedSection).mouseClicked(mouseX, mouseY, button);
+        return sections.get(selectedSection).mouseClicked(click, doubled);
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigScreen.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigScreen.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.input.CharInput;
 import net.minecraft.client.input.KeyInput;
+import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Colors;
 import net.minecraft.util.Identifier;
@@ -44,7 +45,7 @@ public class ConfigScreen extends Screen {
             this.client.setScreen(previousScreen);
         }));
         for (ConfigSection section : sections) {
-            section.init(client, width, height - 55 - 30);
+            section.init(width, height - 55 - 30);
         }
 
         adjustForHorizontalScroll(this.width);

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigScreen.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigScreen.java
@@ -1,6 +1,6 @@
 package net.kyrptonaught.kyrptconfig.config.screen;
 
-import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.opengl.GlStateManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
@@ -162,8 +162,8 @@ public class ConfigScreen extends Screen {
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
         context.getMatrices().push();
-        RenderSystem.enableBlend();
-        RenderSystem.enableDepthTest();
+        GlStateManager._enableBlend();
+        GlStateManager._enableDepthTest();
 
         renderBackgroundTexture(context);
         context.fillGradient(0, 0, this.width, this.height, -1072689136, -804253680);

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigScreen.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigScreen.java
@@ -2,10 +2,11 @@ package net.kyrptonaught.kyrptconfig.config.screen;
 
 import com.mojang.blaze3d.opengl.GlStateManager;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.render.RenderLayer;
 import net.minecraft.text.Text;
+import net.minecraft.util.Colors;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.ColorHelper;
 import net.minecraft.util.math.MathHelper;
@@ -161,7 +162,7 @@ public class ConfigScreen extends Screen {
 
     @Override
     public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        context.getMatrices().push();
+        context.getMatrices().pushMatrix();
         GlStateManager._enableBlend();
         GlStateManager._enableDepthTest();
 
@@ -172,12 +173,10 @@ public class ConfigScreen extends Screen {
 
         section.render(context, 55, mouseX, mouseY, delta);
 
-        context.getMatrices().translate(0, 0, 1);
-
         drawDirtTextureBlurred(context, 0 , 0 ,this.width , 55);
         drawDirtTextureBlurred(context, 0 , this.height - 30 , this.width , 30);
 
-        context.drawCenteredTextWithShadow(this.textRenderer, this.title, this.width / 2, 13, 0xffffff);
+        context.drawCenteredTextWithShadow(this.textRenderer, this.title, this.width / 2, 13, Colors.WHITE);
 
         boolean noHover = scrollLeftBTN.detectHover(mouseX, mouseY) | scrollRightBTN.detectHover(mouseX, mouseY);
         for (int i = 0; i < sections.size(); i++) {
@@ -197,14 +196,11 @@ public class ConfigScreen extends Screen {
         }
 
         if (horizontalScrollOffset > -1) {
-            context.getMatrices().translate(0, 0, 1);
             drawDirtTextureBlurred(context, 0 , 0 ,scrollLeftBTN.getRight() + 1, 55);
             drawDirtTextureBlurred(context, scrollRightBTN.getX() - 1 , 0 ,this.width - (scrollRightBTN.getX()) + 1, 55);
 
             scrollLeftBTN.render(context, mouseX, mouseY, delta);
             scrollRightBTN.render(context, mouseX, mouseY, delta);
-
-            context.getMatrices().translate(0, 0, -1);
         }
 
         if (section.calculateSectionHeight() > 0) {
@@ -218,13 +214,13 @@ public class ConfigScreen extends Screen {
             int y = MathHelper.lerp(percentage, 55, this.height - 30 - height);
 
             context.fill(x, 55, x + 6, this.height - 30, -16777216);
-            context.drawGuiTexture(RenderLayer::getGuiTextured, SCROLLER_TEXTURE, x, y, 6, height);
+            context.drawGuiTexture(RenderPipelines.GUI_TEXTURED, SCROLLER_TEXTURE, x, y, 6, height);
         }
 
         section.render2(context, 55, mouseX, mouseY, delta);
 
         super.render(context, mouseX, mouseY, delta);
-        context.getMatrices().pop();
+        context.getMatrices().popMatrix();
     }
 
     @Override
@@ -232,12 +228,12 @@ public class ConfigScreen extends Screen {
     }
 
     private void renderBackgroundTexture(DrawContext context) {
-        context.drawTexture(RenderLayer::getGuiTextured, OPTIONS_BACKGROUND_TEXTURE, 0, 0, 0, 0, this.width, this.height, 32, 32);
+        context.drawTexture(RenderPipelines.GUI_TEXTURED, OPTIONS_BACKGROUND_TEXTURE, 0, 0, 0, 0, this.width, this.height, 32, 32);
     }
 
     private void drawDirtTextureBlurred(DrawContext context, int x, int y, int width, int height) {
         int color = ColorHelper.fromFloats(.4f, 0, 0, 0);
-        context.drawTexture(RenderLayer::getGuiTextured, OPTIONS_BACKGROUND_TEXTURE, x, y, 0, 0, width, height, 64, 64);
+        context.drawTexture(RenderPipelines.GUI_TEXTURED, OPTIONS_BACKGROUND_TEXTURE, x, y, 0, 0, width, height, 64, 64);
         context.fillGradient(x, y, x + width, y + height, color, color);
     }
 }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigSection.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/ConfigSection.java
@@ -1,8 +1,11 @@
 package net.kyrptonaught.kyrptconfig.config.screen;
 
 import net.kyrptonaught.kyrptconfig.config.screen.items.ConfigItem;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.MathHelper;
 
@@ -62,28 +65,28 @@ public class ConfigSection extends Screen {
         }
     }
 
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyInput input) {
         for (ConfigItem<?> configItem : configs) {
-            if (configItem.keyPressed(keyCode, scanCode, modifiers))
+            if (configItem.keyPressed(input))
                 return true;
         }
         return false;
     }
 
     @Override
-    public boolean charTyped(char chr, int modifiers) {
+    public boolean charTyped(CharInput input) {
         for (ConfigItem<?> configItem : configs) {
-            if (configItem.charTyped(chr, modifiers))
+            if (configItem.charTyped(input))
                 return true;
         }
         return false;
     }
 
-    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+    public boolean mouseClicked(Click click, boolean doubled) {
         for (ConfigItem<?> configItem : configs) {
-            configItem.mouseClicked(mouseX, mouseY, button);
+            configItem.mouseClicked(click, doubled);
         }
-        mouseScrolled(mouseX, mouseY, 0,0); // update scroll if option changes screen size
+        mouseScrolled(click.x(), click.y(), 0,0); // update scroll if option changes screen size
         return false;
     }
 

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/NotSuckyButton.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/NotSuckyButton.java
@@ -1,24 +1,13 @@
 package net.kyrptonaught.kyrptconfig.config.screen;
 
-import com.mojang.blaze3d.pipeline.RenderPipeline;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
-import net.minecraft.client.gl.RenderPipelines;
-import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.gui.screen.ButtonTextures;
 import net.minecraft.client.gui.widget.ButtonWidget;
-import net.minecraft.client.render.RenderLayer;
-import net.minecraft.text.Text;
 import net.minecraft.util.Colors;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.ColorHelper;
 
-public class NotSuckyButton extends ButtonWidget {
+public class NotSuckyButton extends ButtonWidget.Text {
     int buttonColor = Colors.WHITE;
     public boolean disableHover = false;
-    private static final ButtonTextures TEXTURES = new ButtonTextures(Identifier.of("widget/button"), Identifier.of("widget/button_disabled"), Identifier.of("widget/button_highlighted"));
 
-    public NotSuckyButton(int x, int y, int width, int height, Text message, PressAction onPress) {
+    public NotSuckyButton(int x, int y, int width, int height, net.minecraft.text.Text message, PressAction onPress) {
         super(x, y, width, height, message, onPress, DEFAULT_NARRATION_SUPPLIER);
     }
 
@@ -31,23 +20,14 @@ public class NotSuckyButton extends ButtonWidget {
     }
 
     @Override
-    public void renderWidget(DrawContext context, int mouseX, int mouseY, float delta) {
-        //This can fix text rendering over the wrong btn
-        //context.getMatrices().translate(0, 0,  1);
+    public net.minecraft.text.Text getMessage() {
+        net.minecraft.text.Text message = super.getMessage();
+        if (this.active) message = message.copy().withColor(buttonColor);
+        return message;
+    }
 
-        if (disableHover) hovered = false;
-
-        context.drawGuiTexture(
-                RenderPipelines.GUI_TEXTURED,
-                TEXTURES.get(this.active, this.isSelected()),
-                this.getX(),
-                this.getY(),
-                this.getWidth(),
-                this.getHeight(),
-                ColorHelper.getWhite(this.alpha));
-
-        TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
-        int i = this.active ? buttonColor : Colors.LIGHT_GRAY;
-        drawMessage(context, textRenderer, i);
+    @Override
+    public boolean isHovered() {
+        return !disableHover && super.isHovered();
     }
 }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/NotSuckyButton.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/NotSuckyButton.java
@@ -1,17 +1,20 @@
 package net.kyrptonaught.kyrptconfig.config.screen;
 
+import com.mojang.blaze3d.pipeline.RenderPipeline;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gl.RenderPipelines;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ButtonTextures;
 import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.text.Text;
+import net.minecraft.util.Colors;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.ColorHelper;
 
 public class NotSuckyButton extends ButtonWidget {
-    int buttonColor = 16777215;
+    int buttonColor = Colors.WHITE;
     public boolean disableHover = false;
     private static final ButtonTextures TEXTURES = new ButtonTextures(Identifier.of("widget/button"), Identifier.of("widget/button_disabled"), Identifier.of("widget/button_highlighted"));
 
@@ -35,7 +38,7 @@ public class NotSuckyButton extends ButtonWidget {
         if (disableHover) hovered = false;
 
         context.drawGuiTexture(
-                RenderLayer::getGuiTextured,
+                RenderPipelines.GUI_TEXTURED,
                 TEXTURES.get(this.active, this.isSelected()),
                 this.getX(),
                 this.getY(),
@@ -44,7 +47,7 @@ public class NotSuckyButton extends ButtonWidget {
                 ColorHelper.getWhite(this.alpha));
 
         TextRenderer textRenderer = MinecraftClient.getInstance().textRenderer;
-        int i = this.active ? buttonColor : 0xA0A0A0;
+        int i = this.active ? buttonColor : Colors.LIGHT_GRAY;
         drawMessage(context, textRenderer, i);
     }
 }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/BooleanItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/BooleanItem.java
@@ -1,6 +1,7 @@
 package net.kyrptonaught.kyrptconfig.config.screen.items;
 
 import net.kyrptonaught.kyrptconfig.config.screen.NotSuckyButton;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.Text;
 import net.minecraft.util.Colors;
@@ -32,9 +33,9 @@ public class BooleanItem extends ConfigItem<Boolean> {
     }
 
     @Override
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        boolWidget.mouseClicked(mouseX, mouseY, button);
+    public void mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
+        boolWidget.mouseClicked(click, doubled);
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/BooleanItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/BooleanItem.java
@@ -3,7 +3,9 @@ package net.kyrptonaught.kyrptconfig.config.screen.items;
 import net.kyrptonaught.kyrptconfig.config.screen.NotSuckyButton;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.Text;
+import net.minecraft.util.Colors;
 import net.minecraft.util.DyeColor;
+import net.minecraft.util.math.ColorHelper;
 
 public class BooleanItem extends ConfigItem<Boolean> {
     private final NotSuckyButton boolWidget;
@@ -22,10 +24,10 @@ public class BooleanItem extends ConfigItem<Boolean> {
         super.setValue(value);
         if (value) {
             boolWidget.setMessage(Text.translatable("key.kyrptconfig.config.true"));
-            boolWidget.setButtonColor(DyeColor.LIME.getFireworkColor());
+            boolWidget.setButtonColor(ColorHelper.withAlpha(0xff, DyeColor.LIME.getFireworkColor()));
         } else {
             boolWidget.setMessage(Text.translatable("key.kyrptconfig.config.false"));
-            boolWidget.setButtonColor(DyeColor.RED.getSignColor());
+            boolWidget.setButtonColor(Colors.RED);
         }
     }
 

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/ButtonItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/ButtonItem.java
@@ -2,6 +2,7 @@ package net.kyrptonaught.kyrptconfig.config.screen.items;
 
 import net.kyrptonaught.kyrptconfig.config.screen.NotSuckyButton;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.Text;
 
@@ -19,9 +20,9 @@ public class ButtonItem extends ConfigItem {
         return this;
     }
 
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        this.button.mouseClicked(mouseX, mouseY, button);
+    public void mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
+        this.button.mouseClicked(click, doubled);
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/ConfigItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/ConfigItem.java
@@ -2,7 +2,10 @@ package net.kyrptonaught.kyrptconfig.config.screen.items;
 
 import net.kyrptonaught.kyrptconfig.config.screen.NotSuckyButton;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Colors;
@@ -127,17 +130,17 @@ public abstract class ConfigItem<T> {
     public void tick() {
     }
 
-    public void mouseClicked(double mouseX, double mouseY, int button) {
+    public void mouseClicked(Click click, boolean doubled) {
         if (isHidden) return;
         if (resetButton != null)
-            resetButton.mouseClicked(mouseX, mouseY, button);
+            resetButton.mouseClicked(click, doubled);
     }
 
-    public boolean charTyped(char chr, int modifiers) {
+    public boolean charTyped(CharInput input) {
         return false;
     }
 
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyInput input) {
         return false;
     }
 

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/ConfigItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/ConfigItem.java
@@ -5,6 +5,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
+import net.minecraft.util.Colors;
 import net.minecraft.util.Language;
 import net.minecraft.util.math.ColorHelper;
 
@@ -148,7 +149,7 @@ public abstract class ConfigItem<T> {
         if (mouseY > y && mouseY < height)
             context.fill(0, y - 1, width, height + 1, ColorHelper.getArgb(255, 55, 55, 55));
 
-        context.drawText(MinecraftClient.getInstance().textRenderer, this.fieldTitle, x, y + 6, 16777215, true);
+        context.drawText(MinecraftClient.getInstance().textRenderer, this.fieldTitle, x, y + 6, Colors.WHITE, true);
 
         if (resetButton != null) {
             this.resetButton.setY(y);

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/EnumItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/EnumItem.java
@@ -1,6 +1,7 @@
 package net.kyrptonaught.kyrptconfig.config.screen.items;
 
 import net.kyrptonaught.kyrptconfig.config.screen.NotSuckyButton;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.Text;
 
@@ -39,9 +40,9 @@ public class EnumItem<T extends Enum<?>> extends ConfigItem<T> {
     }
 
     @Override
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        displayWidget.mouseClicked(mouseX, mouseY, button);
+    public void mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
+        displayWidget.mouseClicked(click, doubled);
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/KeybindItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/KeybindItem.java
@@ -1,8 +1,10 @@
 package net.kyrptonaught.kyrptconfig.config.screen.items;
 
 import net.kyrptonaught.kyrptconfig.config.screen.NotSuckyButton;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.client.util.InputUtil;
 import net.minecraft.text.MutableText;
@@ -44,25 +46,25 @@ public class KeybindItem extends ConfigItem<String> {
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyInput input) {
         if (isListening) {
-            if (keyCode == GLFW.GLFW_KEY_ESCAPE) {
+            if (input.getKeycode() == GLFW.GLFW_KEY_ESCAPE) {
                 setValue(value);
                 return true;
             }
-            setValue(InputUtil.fromKeyCode(keyCode, scanCode).getTranslationKey());
+            setValue(InputUtil.fromKeyCode(input).getTranslationKey());
             return true;
         }
         return false;
     }
 
     @Override
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
+    public void mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
         boolean handled;
-        handled = (keyButton.mouseClicked(mouseX, mouseY, button) || resetButton.mouseClicked(mouseX, mouseY, button));
+        handled = (keyButton.mouseClicked(click, doubled) || resetButton.mouseClicked(click, doubled));
         if (isListening && !handled) {
-            setValue(InputUtil.Type.MOUSE.createFromCode(button).getTranslationKey());
+            setValue(InputUtil.Type.MOUSE.createFromCode(click.button()).getTranslationKey());
         }
     }
 

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/SubItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/SubItem.java
@@ -1,7 +1,10 @@
 package net.kyrptonaught.kyrptconfig.config.screen.items;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.text.Text;
 
 import java.util.ArrayList;
@@ -50,35 +53,35 @@ public class SubItem<E> extends ConfigItem<E> {
         }
     }
 
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        if (!isHidden() && mouseY > subStart && mouseY < subStart + 20)
+    public void mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
+        if (!isHidden() && click.y() > subStart && click.y() < subStart + 20)
             expanded = !expanded;
 
         if (expanded && !isHidden()) {
             for (ConfigItem<?> item : configs) {
                 if (item.isHidden()) continue;
-                item.mouseClicked(mouseX, mouseY, button);
+                item.mouseClicked(click, doubled);
             }
         }
     }
 
-    public boolean charTyped(char chr, int modifiers) {
+    public boolean charTyped(CharInput input) {
         if (expanded && !isHidden()) {
             for (ConfigItem<?> item : configs) {
                 if (item.isHidden()) continue;
-                if (item.charTyped(chr, modifiers))
+                if (item.charTyped(input))
                     return true;
             }
         }
         return false;
     }
 
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+    public boolean keyPressed(KeyInput input) {
         if (expanded && !isHidden()) {
             for (ConfigItem<?> item : configs) {
                 if (item.isHidden()) continue;
-                if (item.keyPressed(keyCode, scanCode, modifiers))
+                if (item.keyPressed(input))
                     return true;
             }
         }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/TextItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/TextItem.java
@@ -1,8 +1,11 @@
 package net.kyrptonaught.kyrptconfig.config.screen.items;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.text.Text;
 
 public class TextItem extends ConfigItem<String> {
@@ -35,20 +38,20 @@ public class TextItem extends ConfigItem<String> {
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        super.keyPressed(keyCode, scanCode, modifiers);
-        return valueEntry.keyPressed(keyCode, scanCode, modifiers);
+    public boolean keyPressed(KeyInput input) {
+        super.keyPressed(input);
+        return valueEntry.keyPressed(input);
     }
 
     @Override
-    public boolean charTyped(char chr, int modifiers) {
-        return valueEntry.charTyped(chr, modifiers);
+    public boolean charTyped(CharInput input) {
+        return valueEntry.charTyped(input);
     }
 
     @Override
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        valueEntry.setFocused(valueEntry.mouseClicked(mouseX, mouseY, button));
+    public void mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
+        valueEntry.setFocused(valueEntry.mouseClicked(click, doubled));
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/lists/StringList.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/lists/StringList.java
@@ -6,6 +6,7 @@ import net.kyrptonaught.kyrptconfig.config.screen.items.ConfigItem;
 import net.kyrptonaught.kyrptconfig.config.screen.items.SubItem;
 import net.kyrptonaught.kyrptconfig.config.screen.items.lists.entries.ListStringEntry;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.Text;
 import net.minecraft.util.Colors;
@@ -81,10 +82,10 @@ public class StringList extends SubItem<List<String>> {
     }
 
     @Override
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        if (expanded && (addButton.mouseClicked(mouseX, mouseY, button) || clearButton.mouseClicked(mouseX, mouseY, button)) || resetButton.mouseClicked(mouseX, mouseY, button))
+    public void mouseClicked(Click click, boolean doubled) {
+        if (expanded && (addButton.mouseClicked(click, doubled) || clearButton.mouseClicked(click, doubled)) || resetButton.mouseClicked(click, doubled))
             return;
-        super.mouseClicked(mouseX, mouseY, button);
+        super.mouseClicked(click, doubled);
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/lists/StringList.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/lists/StringList.java
@@ -8,6 +8,7 @@ import net.kyrptonaught.kyrptconfig.config.screen.items.lists.entries.ListString
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.text.Text;
+import net.minecraft.util.Colors;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +90,7 @@ public class StringList extends SubItem<List<String>> {
     @Override
     public void render(DrawContext context, int x, int y, int mouseX, int mouseY, float delta) {
         super.render(context, x, y, mouseX, mouseY, delta);
-        context.drawText(MinecraftClient.getInstance().textRenderer, expanded ? "-" : "+", x - 10, y + 5, 16777215, false);
+        context.drawText(MinecraftClient.getInstance().textRenderer, expanded ? "-" : "+", x - 10, y + 5, Colors.WHITE, false);
         subStart = y;
         if (expanded) {
             this.clearButton.setY(y);

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/lists/entries/IconEntry.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/lists/entries/IconEntry.java
@@ -1,18 +1,9 @@
 package net.kyrptonaught.kyrptconfig.config.screen.items.lists.entries;
 
-import com.mojang.blaze3d.platform.GlStateManager;
-import com.mojang.blaze3d.systems.RenderSystem;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
-import net.minecraft.client.render.DiffuseLighting;
-import net.minecraft.client.render.OverlayTexture;
-import net.minecraft.client.render.VertexConsumerProvider;
-import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.texture.SpriteAtlasTexture;
 import net.minecraft.item.ItemConvertible;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.item.ModelTransformationMode;
 
 import java.util.List;
 
@@ -45,30 +36,6 @@ public class IconEntry<E> extends ListStringEntry {
         super.render(context, x, y, mouseX, mouseY, delta);
         if (deleted) return;
         ItemConvertible item = getItemToRender(delta);
-        renderGuiItemModel(context, new ItemStack(item), x, y);
-    }
-
-    protected void renderGuiItemModel(DrawContext context, ItemStack stack, int x, int y) {
-        context.getMatrices().push();
-        MinecraftClient.getInstance().getTextureManager().getTexture(SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE).setFilter(false, false);
-        RenderSystem.setShaderTexture(0, SpriteAtlasTexture.BLOCK_ATLAS_TEXTURE);
-        RenderSystem.blendFunc(GlStateManager.SrcFactor.SRC_ALPHA, GlStateManager.DstFactor.ONE_MINUS_SRC_ALPHA);
-        RenderSystem.setShaderColor(1.0f, 1.0f, 1.0f, 1.0f);
-        context.getMatrices().translate(x, y, 100);
-        context.getMatrices().translate(8.0, 8.0, 0.0);
-        context.getMatrices().scale(1.0f, -1.0f, 1.0f);
-        context.getMatrices().scale(16.0f, 16.0f, 16.0f);
-        VertexConsumerProvider.Immediate immediate = MinecraftClient.getInstance().getBufferBuilders().getEntityVertexConsumers();
-        boolean bl = false;
-        if (bl) {
-            DiffuseLighting.disableGuiDepthLighting();
-        }
-        MinecraftClient.getInstance().getItemRenderer().renderItem(null, stack, ModelTransformationMode.GUI, false, context.getMatrices(), immediate, null, 0, OverlayTexture.DEFAULT_UV, 6);
-
-        immediate.draw();
-        if (bl) {
-            DiffuseLighting.enableGuiDepthLighting();
-        }
-        context.getMatrices().pop();
+        context.drawItem(new ItemStack(item), x, y);
     }
 }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/lists/entries/ListStringEntry.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/lists/entries/ListStringEntry.java
@@ -3,8 +3,11 @@ package net.kyrptonaught.kyrptconfig.config.screen.items.lists.entries;
 import net.kyrptonaught.kyrptconfig.config.screen.NotSuckyButton;
 import net.kyrptonaught.kyrptconfig.config.screen.items.ConfigItem;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.text.Text;
 
 public class ListStringEntry extends ConfigItem<String> {
@@ -40,24 +43,24 @@ public class ListStringEntry extends ConfigItem<String> {
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        super.keyPressed(keyCode, scanCode, modifiers);
+    public boolean keyPressed(KeyInput input) {
+        super.keyPressed(input);
         if (deleted) return false;
-        return valueEntry.keyPressed(keyCode, scanCode, modifiers);
+        return valueEntry.keyPressed(input);
     }
 
     @Override
-    public boolean charTyped(char chr, int modifiers) {
+    public boolean charTyped(CharInput input) {
         if (deleted) return false;
-        return valueEntry.charTyped(chr, modifiers);
+        return valueEntry.charTyped(input);
     }
 
     @Override
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
+    public void mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
         if (deleted) return;
-        delButton.mouseClicked(mouseX, mouseY, button);
-        valueEntry.setFocused(valueEntry.mouseClicked(mouseX, mouseY, button));
+        delButton.mouseClicked(click, doubled);
+        valueEntry.setFocused(valueEntry.mouseClicked(click, doubled));
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/number/NumberItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/number/NumberItem.java
@@ -2,12 +2,14 @@ package net.kyrptonaught.kyrptconfig.config.screen.items.number;
 
 import net.kyrptonaught.kyrptconfig.config.screen.items.ConfigItem;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Click;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.input.CharInput;
+import net.minecraft.client.input.KeyInput;
 import net.minecraft.text.Text;
 import net.minecraft.util.Colors;
-import net.minecraft.util.DyeColor;
 
 import java.math.BigDecimal;
 import java.util.Objects;
@@ -91,20 +93,20 @@ public abstract class NumberItem<T extends Number> extends ConfigItem<T> {
     }
 
     @Override
-    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
-        super.keyPressed(keyCode, scanCode, modifiers);
-        return valueEntry.keyPressed(keyCode, scanCode, modifiers);
+    public boolean keyPressed(KeyInput input) {
+        super.keyPressed(input);
+        return valueEntry.keyPressed(input);
     }
 
     @Override
-    public boolean charTyped(char chr, int modifiers) {
-        return valueEntry.charTyped(chr, modifiers);
+    public boolean charTyped(CharInput input) {
+        return valueEntry.charTyped(input);
     }
 
     @Override
-    public void mouseClicked(double mouseX, double mouseY, int button) {
-        super.mouseClicked(mouseX, mouseY, button);
-        valueEntry.setFocused(valueEntry.mouseClicked(mouseX, mouseY, button));
+    public void mouseClicked(Click click, boolean doubled) {
+        super.mouseClicked(click, doubled);
+        valueEntry.setFocused(valueEntry.mouseClicked(click, doubled));
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/number/NumberItem.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/config/screen/items/number/NumberItem.java
@@ -6,6 +6,7 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.tooltip.Tooltip;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.text.Text;
+import net.minecraft.util.Colors;
 import net.minecraft.util.DyeColor;
 
 import java.math.BigDecimal;
@@ -52,9 +53,9 @@ public abstract class NumberItem<T extends Number> extends ConfigItem<T> {
     public void onTyped(String s) {
         boolean isValid = isValid(s);
         if (isValid) {
-            valueEntry.setEditableColor(0xE0E0E0);
+            valueEntry.setEditableColor(0xE0E0E0E0);
         } else {
-            valueEntry.setEditableColor(DyeColor.RED.getSignColor());
+            valueEntry.setEditableColor(Colors.RED);
         }
         lastInputFixed = false;
     }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/example/ExampleConfig.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/example/ExampleConfig.java
@@ -10,6 +10,7 @@ import net.kyrptonaught.kyrptconfig.config.screen.items.ButtonItem;
 import net.kyrptonaught.kyrptconfig.config.screen.items.KeybindItem;
 import net.kyrptonaught.kyrptconfig.config.screen.items.TextItem;
 import net.kyrptonaught.kyrptconfig.config.screen.items.lists.BlockIconList;
+import net.kyrptonaught.kyrptconfig.config.screen.items.lists.ItemIconList;
 import net.kyrptonaught.kyrptconfig.config.screen.items.lists.StringList;
 import net.kyrptonaught.kyrptconfig.config.screen.items.number.FloatItem;
 import net.kyrptonaught.kyrptconfig.config.screen.items.number.IntegerItem;
@@ -61,6 +62,8 @@ public class ExampleConfig implements ModMenuApi {
             blackListSection.addConfigItem(hideList);
 
             blackListSection.addConfigItem(new BlockIconList(Text.translatable("key.diggusmaximus.config.blacklist"), new ArrayList<>(), new ArrayList<>(), true));
+
+            blackListSection.addConfigItem(new ItemIconList(Text.translatable("key.diggusmaximus.config.itemList"), new ArrayList<>(), new ArrayList<>(), true));
 
             new ConfigSection(configScreen, Text.literal("Tab Test 1"));
             new ConfigSection(configScreen, Text.literal("Tab Test 2"));

--- a/src/main/java/net/kyrptonaught/kyrptconfig/keybinding/DisplayOnlyKeyBind.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/keybinding/DisplayOnlyKeyBind.java
@@ -9,13 +9,13 @@ public class DisplayOnlyKeyBind extends KeyBinding {
     private CustomKeyBinding customKeyBinding;
     private final Consumer<InputUtil.Key> keySet;
 
-    public DisplayOnlyKeyBind(String translationKey, InputUtil.Type type, int code, String category) {
+    public DisplayOnlyKeyBind(String translationKey, InputUtil.Type type, int code, KeyBinding.Category category) {
         super(translationKey, type, code, category);
         keySet = (boundKey) -> {
         };
     }
 
-    public DisplayOnlyKeyBind(String translationKey, String category, CustomKeyBinding customKeyBinding, Consumer<InputUtil.Key> keySet) {
+    public DisplayOnlyKeyBind(String translationKey, KeyBinding.Category category, CustomKeyBinding customKeyBinding, Consumer<InputUtil.Key> keySet) {
         super(translationKey, customKeyBinding.getDefaultKey().getCategory(), customKeyBinding.getDefaultKey().getCode(), category);
         this.customKeyBinding = customKeyBinding;
         this.keySet = keySet;
@@ -34,15 +34,15 @@ public class DisplayOnlyKeyBind extends KeyBinding {
     }
 
     @Override
-    public String getCategory() {
+    public KeyBinding.Category getCategory() {
         updateSetKey();
         return super.getCategory();
     }
 
     @Override
-    public String getTranslationKey() {
+    public String getBoundKeyTranslationKey() {
         updateSetKey();
-        return super.getTranslationKey();
+        return super.getBoundKeyTranslationKey();
     }
 
     @Override

--- a/src/main/java/net/kyrptonaught/kyrptconfig/mixin/displaykeybind/GameOptionsMixin.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/mixin/displaykeybind/GameOptionsMixin.java
@@ -24,7 +24,7 @@ public class GameOptionsMixin {
         SpoofedKeysHelper.spoofed_Keys.clear();
         for (KeyBinding keyBinding : this.allKeys) {
             if (keyBinding instanceof DisplayOnlyKeyBind)
-                SpoofedKeysHelper.spoofed_Keys.add("key_" + keyBinding.getTranslationKey());
+                SpoofedKeysHelper.spoofed_Keys.add("key_" + keyBinding.getBoundKeyTranslationKey());
         }
     }
 }

--- a/src/main/java/net/kyrptonaught/kyrptconfig/mixin/nonConflicting/KeyBindingMixin.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/mixin/nonConflicting/KeyBindingMixin.java
@@ -12,7 +12,7 @@ import java.util.Map;
 @Mixin(KeyBinding.class)
 public class KeyBindingMixin {
 
-    @WrapWithCondition(method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILnet/minecraft/client/option/KeyBinding$Category;)V", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+    @WrapWithCondition(method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILnet/minecraft/client/option/KeyBinding$Category;I)V", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
     public <K, V> boolean dontRegister(Map<K, V> instance, K k, V v) {
         if (((Object) this instanceof NonConflictingKeyBinding))
             return false;
@@ -21,7 +21,7 @@ public class KeyBindingMixin {
     }
 
     @com.llamalad7.mixinextras.injector.v2.WrapWithCondition(
-            method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILnet/minecraft/client/option/KeyBinding$Category;)V",
+            method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILnet/minecraft/client/option/KeyBinding$Category;I)V",
             at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/KeyBinding;registerBinding(Lnet/minecraft/client/util/InputUtil$Key;)V")
     )
     public boolean dontRegisterBinding(KeyBinding keyBinding, InputUtil.Key key) {

--- a/src/main/java/net/kyrptonaught/kyrptconfig/mixin/nonConflicting/KeyBindingMixin.java
+++ b/src/main/java/net/kyrptonaught/kyrptconfig/mixin/nonConflicting/KeyBindingMixin.java
@@ -3,6 +3,7 @@ package net.kyrptonaught.kyrptconfig.mixin.nonConflicting;
 import com.llamalad7.mixinextras.injector.WrapWithCondition;
 import net.kyrptonaught.kyrptconfig.config.NonConflicting.NonConflictingKeyBinding;
 import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
@@ -11,8 +12,19 @@ import java.util.Map;
 @Mixin(KeyBinding.class)
 public class KeyBindingMixin {
 
-    @WrapWithCondition(method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILjava/lang/String;)V", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
+    @WrapWithCondition(method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILnet/minecraft/client/option/KeyBinding$Category;)V", at = @At(value = "INVOKE", target = "Ljava/util/Map;put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"))
     public <K, V> boolean dontRegister(Map<K, V> instance, K k, V v) {
+        if (((Object) this instanceof NonConflictingKeyBinding))
+            return false;
+
+        return true;
+    }
+
+    @com.llamalad7.mixinextras.injector.v2.WrapWithCondition(
+            method = "<init>(Ljava/lang/String;Lnet/minecraft/client/util/InputUtil$Type;ILnet/minecraft/client/option/KeyBinding$Category;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/KeyBinding;registerBinding(Lnet/minecraft/client/util/InputUtil$Key;)V")
+    )
+    public boolean dontRegisterBinding(KeyBinding keyBinding, InputUtil.Key key) {
         if (((Object) this instanceof NonConflictingKeyBinding))
             return false;
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "kyrptconfig",
-  "version": "1.6.1-1.21.5",
+  "version": "1.6.2-1.21.6",
   "name": "Kyrpt Config",
   "description": "Config library used in my mods",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "kyrptconfig",
-  "version": "1.6.2-1.21.6",
+  "version": "1.6.2-1.21.8",
   "name": "Kyrpt Config",
   "description": "Config library used in my mods",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "kyrptconfig",
-  "version": "1.6.1-1.21.4",
+  "version": "1.6.1-1.21.5",
   "name": "Kyrpt Config",
   "description": "Config library used in my mods",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "kyrptconfig",
-  "version": "1.6.2-1.21.8",
+  "version": "1.6.3-1.21.9",
   "name": "Kyrpt Config",
   "description": "Config library used in my mods",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "kyrptconfig",
-  "version": "1.6.3-1.21.10",
+  "version": "1.6.4-1.21.11",
   "name": "Kyrpt Config",
   "description": "Config library used in my mods",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "kyrptconfig",
-  "version": "1.6.3-1.21.9",
+  "version": "1.6.3-1.21.10",
   "name": "Kyrpt Config",
   "description": "Config library used in my mods",
   "authors": [


### PR DESCRIPTION
All commits were tested, but only 1.21.11 was thoroughly tested.

Branch to migrate to Mojang official mappings once this PR is merged: https://github.com/PrivacyPolicy/kyrptconfig/tree/1.21-mojang-mappings

## Behavior Changes
Minecraft will show a 🚫 symbol when hovering over a disabled button. kryptconfig buttons now do so, which is not how they behaved prior to this update. It can easily be returned to the previous behavior (no cursor changes on hovering disabled button) by adding this override in `NotSuckyButton.java`:

```java
@Override
protected void setCursor(DrawContext context) {
    context.setCursor(Cursor.DEFAULT);
}
```